### PR TITLE
use one struct for service and repository

### DIFF
--- a/src/handler/item.rs
+++ b/src/handler/item.rs
@@ -32,7 +32,7 @@ async fn list_items(
     State(state): State<Arc<AppState>>,
     Extension(correlation_id): Extension<CorrelationId>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.service.item.list().await {
+    match state.service.list_item().await {
         Ok(items) => (
             StatusCode::OK,
             Json(json!(Response::<Vec<Item>> {
@@ -59,7 +59,7 @@ async fn create_item(
     Extension(correlation_id): Extension<CorrelationId>,
     Json(payload): Json<CreateItem>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.service.item.create(payload.name).await {
+    match state.service.create_item(payload.name).await {
         Ok(item) => (
             StatusCode::CREATED,
             Json(json!(Response::<Item> {
@@ -86,7 +86,7 @@ async fn get_item(
     Extension(correlation_id): Extension<CorrelationId>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.service.item.get(id).await {
+    match state.service.get_item(id).await {
         Ok(item) => (
             StatusCode::OK,
             Json(json!(Response::<Item> {
@@ -114,7 +114,7 @@ async fn update_item(
     axum::extract::Path(id): axum::extract::Path<String>,
     Json(payload): Json<UpdateItem>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.service.item.update(id, payload.name.clone()).await {
+    match state.service.update_item(id, payload.name.clone()).await {
         Ok(item) => (
             StatusCode::OK,
             Json(json!(Response::<Item> {
@@ -141,7 +141,7 @@ async fn delete_item(
     Extension(correlation_id): Extension<CorrelationId>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.service.item.delete(id.clone()).await {
+    match state.service.delete_item(id.clone()).await {
         Ok(_) => (
             StatusCode::OK,
             Json(json!(Response::<serde_json::Value> {

--- a/src/handler/user.rs
+++ b/src/handler/user.rs
@@ -27,7 +27,7 @@ async fn add_user(
     Extension(correlation_id): Extension<CorrelationId>,
     Json(payload): Json<CreateUser>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.service.user.add(payload).await {
+    match state.service.add_user(payload).await {
         Ok(user) => (
             StatusCode::CREATED,
             Json(json!(Response::<User> {
@@ -53,7 +53,7 @@ async fn list_users(
     State(state): State<Arc<AppState>>,
     Extension(correlation_id): Extension<CorrelationId>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.service.user.list().await {
+    match state.service.list_user().await {
         Ok(users) => (
             StatusCode::OK,
             Json(json!(Response::<Vec<User>> {
@@ -79,7 +79,7 @@ async fn get_user(
     Extension(correlation_id): Extension<CorrelationId>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.service.user.get(&id).await {
+    match state.service.get_user(&id).await {
         Ok(user) => (
             StatusCode::OK,
             Json(json!(Response::<User> {
@@ -107,7 +107,7 @@ async fn update_user(
     axum::extract::Path(id): axum::extract::Path<String>,
     Json(payload): Json<UpdateUser>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.service.user.update(&id, payload).await {
+    match state.service.update_user(&id, payload).await {
         Ok(user) => (
             StatusCode::OK,
             Json(json!(Response::<User> {
@@ -134,7 +134,7 @@ async fn delete_user(
     Extension(correlation_id): Extension<CorrelationId>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    match state.service.user.delete(&id).await {
+    match state.service.delete_user(&id).await {
         Ok(_) => (
             StatusCode::OK,
             Json(json!(Response::<serde_json::Value> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use crud_rust::{
     handler::{item::router_setup_items, user::router_setup_users},
     middleware::{CorrelationId, request_middleware},
     model::http::Response,
-    repository::PostgresRepository,
+    repository::{PostgresRepository, Repository},
     service::Service,
     state::AppState,
 };
@@ -38,7 +38,7 @@ async fn main() {
         }
     };
 
-    let repo = Arc::new(PostgresRepository::new(pool.clone()));
+    let repo: Arc<dyn Repository> = Arc::new(PostgresRepository::new(pool.clone()));
     let service = Arc::new(Service::new(config.clone(), repo.clone()));
 
     let app_state = Arc::new(AppState {

--- a/src/repository/item.rs
+++ b/src/repository/item.rs
@@ -1,237 +1,93 @@
-use async_trait::async_trait;
 use sqlx::PgPool;
-use std::sync::Mutex;
 
 use crate::model::{
     error::{AppError, AppErrorCode},
     item::Item,
 };
 
-#[async_trait]
-#[cfg_attr(test, mockall::automock)]
-pub trait ItemRepository: Send + Sync {
-    async fn add(&self, item: Item) -> Result<Item, AppError>;
-    async fn list(&self) -> Result<Vec<Item>, AppError>;
-    async fn get(&self, id: &str) -> Result<Item, AppError>;
-    async fn update(&self, id: &str, name: String) -> Result<Item, AppError>;
-    async fn delete(&self, id: &str) -> Result<(), AppError>;
+pub async fn add_item(db: &PgPool, item: Item) -> Result<Item, AppError> {
+    let row = sqlx::query_as!(
+        Item,
+        r#"
+            INSERT INTO items (id, name)
+            VALUES ($1, $2)
+            ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+            RETURNING id, name
+        "#,
+        item.id,
+        item.name
+    )
+    .fetch_one(db)
+    .await
+    .map_err(|e| AppError {
+        code: AppErrorCode::InternalError(e.to_string()),
+        message: "Failed to upsert item".to_string(),
+    })?;
+    Ok(row)
 }
 
-pub struct InMemoryItemRepository {
-    pub items: Mutex<Vec<Item>>,
-}
-
-impl Default for InMemoryItemRepository {
-    fn default() -> Self {
-        Self {
-            items: Mutex::new(Vec::new()),
-        }
-    }
-}
-
-impl InMemoryItemRepository {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-#[async_trait]
-impl ItemRepository for InMemoryItemRepository {
-    async fn add(&self, new_item: Item) -> Result<Item, AppError> {
-        match self.items.lock() {
-            Ok(mut items) => {
-                let cur = items.iter().find(|item| item.name == new_item.name);
-                match cur {
-                    Some(item) => Ok(item.clone()),
-                    None => {
-                        items.push(new_item.clone());
-                        Ok(new_item)
-                    }
-                }
-            }
-            Err(e) => Err(AppError {
-                code: AppErrorCode::InternalError(e.to_string()),
-                message: "Failed to lock items".to_string(),
-            }),
-        }
-    }
-
-    async fn list(&self) -> Result<Vec<Item>, AppError> {
-        match self.items.lock() {
-            Ok(items) => Ok(items.clone()),
-            Err(e) => Err(AppError {
-                code: AppErrorCode::InternalError(e.to_string()),
-                message: "Failed to lock items".to_string(),
-            }),
-        }
-    }
-
-    async fn get(&self, id: &str) -> Result<Item, AppError> {
-        match self.items.lock() {
-            Ok(items) => {
-                let item = items.iter().find(|item| item.id == id);
-                match item {
-                    Some(item) => Ok(item.clone()),
-                    None => Err(AppError {
-                        code: AppErrorCode::NotFound,
-                        message: format!("Item with id {} not found", id),
-                    }),
-                }
-            }
-            Err(e) => Err(AppError {
-                code: AppErrorCode::InternalError(e.to_string()),
-                message: "Failed to lock items".to_string(),
-            }),
-        }
-    }
-
-    async fn update(&self, id: &str, name: String) -> Result<Item, AppError> {
-        match self.items.lock() {
-            Ok(mut items) => {
-                let index = match items.iter().position(|item| item.id == id) {
-                    Some(index) => index,
-                    None => {
-                        return Err(AppError {
-                            code: AppErrorCode::NotFound,
-                            message: format!("Item with id {} not found", id),
-                        });
-                    }
-                };
-                let cur = match items.get(index) {
-                    Some(item) => item.clone(),
-                    None => {
-                        return Err(AppError {
-                            code: AppErrorCode::NotFound,
-                            message: format!("Item with id {} not found", id),
-                        });
-                    }
-                };
-
-                let updated_item = Item { name, ..cur };
-                items[index] = updated_item.clone();
-                Ok(updated_item)
-            }
-            Err(e) => Err(AppError {
-                code: AppErrorCode::InternalError(e.to_string()),
-                message: "Failed to lock items".to_string(),
-            }),
-        }
-    }
-
-    async fn delete(&self, id: &str) -> Result<(), AppError> {
-        match self.items.lock() {
-            Ok(mut items) => {
-                *items = items
-                    .clone()
-                    .into_iter()
-                    .filter(|item| item.id != id)
-                    .collect();
-                Ok(())
-            }
-            Err(e) => Err(AppError {
-                code: AppErrorCode::InternalError(e.to_string()),
-                message: "Failed to lock items".to_string(),
-            }),
-        }
-    }
-}
-
-pub struct PostgresItemRepository {
-    db: PgPool,
-}
-
-impl PostgresItemRepository {
-    pub fn new(db: PgPool) -> Self {
-        Self { db }
-    }
-}
-
-#[async_trait]
-impl ItemRepository for PostgresItemRepository {
-    async fn add(&self, item: Item) -> Result<Item, AppError> {
-        let row = sqlx::query_as!(
-            Item,
-            r#"
-                INSERT INTO items (id, name)
-                VALUES ($1, $2)
-                ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
-                RETURNING id, name
-            "#,
-            item.id,
-            item.name
-        )
-        .fetch_one(&self.db)
+pub async fn list_item(db: &PgPool) -> Result<Vec<Item>, AppError> {
+    let rows = sqlx::query_as!(Item, r#"SELECT id, name FROM items ORDER BY name ASC"#)
+        .fetch_all(db)
         .await
         .map_err(|e| AppError {
             code: AppErrorCode::InternalError(e.to_string()),
-            message: "Failed to upsert item".to_string(),
+            message: "Failed to fetch items".to_string(),
         })?;
-        Ok(row)
-    }
+    Ok(rows)
+}
 
-    async fn list(&self) -> Result<Vec<Item>, AppError> {
-        let rows = sqlx::query_as!(Item, r#"SELECT id, name FROM items ORDER BY name ASC"#)
-            .fetch_all(&self.db)
-            .await
-            .map_err(|e| AppError {
-                code: AppErrorCode::InternalError(e.to_string()),
-                message: "Failed to fetch items".to_string(),
-            })?;
-        Ok(rows)
-    }
-
-    async fn get(&self, id: &str) -> Result<Item, AppError> {
-        let row = sqlx::query_as!(Item, r#"SELECT id, name FROM items WHERE id = $1"#, id)
-            .fetch_optional(&self.db)
-            .await
-            .map_err(|e| AppError {
-                code: AppErrorCode::InternalError(e.to_string()),
-                message: "Failed to fetch item".to_string(),
-            })?;
-        match row {
-            Some(row) => Ok(row),
-            None => Err(AppError {
-                code: AppErrorCode::NotFound,
-                message: format!("Item with id {} not found", id),
-            }),
-        }
-    }
-
-    async fn update(&self, id: &str, name: String) -> Result<Item, AppError> {
-        let row = sqlx::query_as!(
-            Item,
-            r#"
-                UPDATE items
-                SET name = $2
-                WHERE id = $1
-                RETURNING id, name
-            "#,
-            id,
-            name
-        )
-        .fetch_optional(&self.db)
+pub async fn get_item(db: &PgPool, id: &str) -> Result<Item, AppError> {
+    let row = sqlx::query_as!(Item, r#"SELECT id, name FROM items WHERE id = $1"#, id)
+        .fetch_optional(db)
         .await
         .map_err(|e| AppError {
             code: AppErrorCode::InternalError(e.to_string()),
-            message: "Failed to update item".to_string(),
+            message: "Failed to fetch item".to_string(),
         })?;
-        match row {
-            Some(row) => Ok(row),
-            None => Err(AppError {
-                code: AppErrorCode::NotFound,
-                message: format!("Item with id {} not found", id),
-            }),
-        }
+    match row {
+        Some(row) => Ok(row),
+        None => Err(AppError {
+            code: AppErrorCode::NotFound,
+            message: format!("Item with id {} not found", id),
+        }),
     }
+}
 
-    async fn delete(&self, id: &str) -> Result<(), AppError> {
-        sqlx::query!("DELETE FROM items WHERE id = $1", id)
-            .execute(&self.db)
-            .await
-            .map_err(|e| AppError {
-                code: AppErrorCode::InternalError(e.to_string()),
-                message: "Failed to delete item".to_string(),
-            })?;
-        Ok(())
+pub async fn update_item(db: &PgPool, id: &str, name: String) -> Result<Item, AppError> {
+    let row = sqlx::query_as!(
+        Item,
+        r#"
+            UPDATE items
+            SET name = $2
+            WHERE id = $1
+            RETURNING id, name
+        "#,
+        id,
+        name
+    )
+    .fetch_optional(db)
+    .await
+    .map_err(|e| AppError {
+        code: AppErrorCode::InternalError(e.to_string()),
+        message: "Failed to update item".to_string(),
+    })?;
+    match row {
+        Some(row) => Ok(row),
+        None => Err(AppError {
+            code: AppErrorCode::NotFound,
+            message: format!("Item with id {} not found", id),
+        }),
     }
+}
+
+pub async fn delete_item(db: &PgPool, id: &str) -> Result<(), AppError> {
+    sqlx::query!("DELETE FROM items WHERE id = $1", id)
+        .execute(db)
+        .await
+        .map_err(|e| AppError {
+            code: AppErrorCode::InternalError(e.to_string()),
+            message: "Failed to delete item".to_string(),
+        })?;
+    Ok(())
 }

--- a/src/repository/registry.rs
+++ b/src/repository/registry.rs
@@ -1,38 +1,75 @@
-use std::sync::Arc;
-
 use sqlx::PgPool;
 
-use super::{
-    item::{ItemRepository, PostgresItemRepository},
-    user::{PostgresUserRepository, UserRepository},
-};
+use crate::model::{error::AppError, item::Item, user::User};
 
-pub trait Repository: Send + Sync {
-    fn item(&self) -> Arc<dyn ItemRepository>;
-    fn user(&self) -> Arc<dyn UserRepository>;
+use super::item::{add_item, delete_item, get_item, list_item, update_item};
+use super::user::{add_user, delete_user, get_user, list_user, update_user};
+
+#[async_trait::async_trait]
+#[cfg_attr(test, mockall::automock)]
+pub trait Repository: Sync + Send {
+    async fn add_item(&self, item: Item) -> Result<Item, AppError>;
+    async fn list_item(&self) -> Result<Vec<Item>, AppError>;
+    async fn get_item(&self, id: &str) -> Result<Item, AppError>;
+    async fn update_item(&self, id: &str, name: String) -> Result<Item, AppError>;
+    async fn delete_item(&self, id: &str) -> Result<(), AppError>;
+
+    async fn add_user(&self, user: User) -> Result<User, AppError>;
+    async fn list_user(&self) -> Result<Vec<User>, AppError>;
+    async fn get_user(&self, id: &str) -> Result<User, AppError>;
+    async fn update_user(&self, id: &str, name: String) -> Result<User, AppError>;
+    async fn delete_user(&self, id: &str) -> Result<(), AppError>;
 }
 
 pub struct PostgresRepository {
-    pub item: Arc<PostgresItemRepository>,
-    pub user: Arc<PostgresUserRepository>,
-}
-
-#[cfg_attr(test, mockall::automock)]
-impl Repository for PostgresRepository {
-    fn item(&self) -> Arc<dyn ItemRepository> {
-        self.item.clone()
-    }
-
-    fn user(&self) -> Arc<dyn UserRepository> {
-        self.user.clone()
-    }
+    pub db: PgPool,
 }
 
 impl PostgresRepository {
     pub fn new(db: PgPool) -> Self {
-        Self {
-            item: Arc::new(PostgresItemRepository::new(db.clone())),
-            user: Arc::new(PostgresUserRepository::new(db.clone())),
-        }
+        Self { db }
+    }
+}
+
+#[async_trait::async_trait]
+impl Repository for PostgresRepository {
+    async fn add_item(&self, item: Item) -> Result<Item, AppError> {
+        add_item(&self.db, item).await
+    }
+
+    async fn list_item(&self) -> Result<Vec<Item>, AppError> {
+        list_item(&self.db).await
+    }
+
+    async fn get_item(&self, id: &str) -> Result<Item, AppError> {
+        get_item(&self.db, id).await
+    }
+
+    async fn update_item(&self, id: &str, name: String) -> Result<Item, AppError> {
+        update_item(&self.db, id, name).await
+    }
+
+    async fn delete_item(&self, id: &str) -> Result<(), AppError> {
+        delete_item(&self.db, id).await
+    }
+
+    async fn add_user(&self, user: User) -> Result<User, AppError> {
+        add_user(&self.db, user).await
+    }
+
+    async fn list_user(&self) -> Result<Vec<User>, AppError> {
+        list_user(&self.db).await
+    }
+
+    async fn get_user(&self, id: &str) -> Result<User, AppError> {
+        get_user(&self.db, id).await
+    }
+
+    async fn update_user(&self, id: &str, name: String) -> Result<User, AppError> {
+        update_user(&self.db, id, name).await
+    }
+
+    async fn delete_user(&self, id: &str) -> Result<(), AppError> {
+        delete_user(&self.db, id).await
     }
 }

--- a/src/repository/user.rs
+++ b/src/repository/user.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use sqlx::PgPool;
 
 use crate::model::{
@@ -6,112 +5,89 @@ use crate::model::{
     user::User,
 };
 
-#[async_trait]
-#[cfg_attr(test, mockall::automock)]
-pub trait UserRepository: Send + Sync {
-    async fn add(&self, user: User) -> Result<User, AppError>;
-    async fn list(&self) -> Result<Vec<User>, AppError>;
-    async fn get(&self, id: &str) -> Result<User, AppError>;
-    async fn update(&self, id: &str, name: String) -> Result<User, AppError>;
-    async fn delete(&self, id: &str) -> Result<(), AppError>;
+pub async fn add_user(db: &PgPool, user: User) -> Result<User, AppError> {
+    let row = sqlx::query_as!(
+        User,
+        r#"
+            INSERT INTO users (id, email)
+            VALUES ($1, $2)
+            ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email
+            RETURNING id, email
+        "#,
+        user.id,
+        user.email,
+    )
+    .fetch_one(db)
+    .await
+    .map_err(|e| AppError {
+        code: AppErrorCode::InternalError(e.to_string()),
+        message: "Failed to upsert user".to_string(),
+    })?;
+    Ok(row)
 }
 
-pub struct PostgresUserRepository {
-    db: PgPool,
-}
-
-impl PostgresUserRepository {
-    pub fn new(db: PgPool) -> Self {
-        Self { db }
-    }
-}
-
-#[async_trait]
-impl UserRepository for PostgresUserRepository {
-    async fn add(&self, user: User) -> Result<User, AppError> {
-        let row = sqlx::query_as!(
-            User,
-            r#"
-                INSERT INTO users (id, email)
-                VALUES ($1, $2)
-                ON CONFLICT (email) DO UPDATE SET email = EXCLUDED.email
-                RETURNING id, email
-            "#,
-            user.id,
-            user.email,
-        )
-        .fetch_one(&self.db)
+pub async fn list_user(db: &PgPool) -> Result<Vec<User>, AppError> {
+    let rows = sqlx::query_as!(User, r#"SELECT id, email FROM users ORDER BY email ASC"#)
+        .fetch_all(db)
         .await
         .map_err(|e| AppError {
             code: AppErrorCode::InternalError(e.to_string()),
-            message: "Failed to upsert user".to_string(),
+            message: "Failed to fetch users".to_string(),
         })?;
-        Ok(row)
-    }
+    Ok(rows)
+}
 
-    async fn list(&self) -> Result<Vec<User>, AppError> {
-        let rows = sqlx::query_as!(User, r#"SELECT id, email FROM users ORDER BY email ASC"#)
-            .fetch_all(&self.db)
-            .await
-            .map_err(|e| AppError {
-                code: AppErrorCode::InternalError(e.to_string()),
-                message: "Failed to fetch users".to_string(),
-            })?;
-        Ok(rows)
-    }
-
-    async fn get(&self, id: &str) -> Result<User, AppError> {
-        let row = sqlx::query_as!(User, r#"SELECT id, email FROM users WHERE id = $1"#, id)
-            .fetch_optional(&self.db)
-            .await
-            .map_err(|e| AppError {
-                code: AppErrorCode::InternalError(e.to_string()),
-                message: "Failed to fetch user".to_string(),
-            })?;
-        match row {
-            Some(row) => Ok(row),
-            None => Err(AppError {
-                code: AppErrorCode::NotFound,
-                message: format!("User with id {} not found", id),
-            }),
-        }
-    }
-
-    async fn update(&self, id: &str, email: String) -> Result<User, AppError> {
-        let row = sqlx::query_as!(
-            User,
-            r#"
-                UPDATE users
-                SET email = $2
-                WHERE id = $1
-                RETURNING id, email
-            "#,
-            id,
-            email
-        )
-        .fetch_optional(&self.db)
+pub async fn get_user(db: &PgPool, id: &str) -> Result<User, AppError> {
+    let row = sqlx::query_as!(User, r#"SELECT id, email FROM users WHERE id = $1"#, id)
+        .fetch_optional(db)
         .await
         .map_err(|e| AppError {
             code: AppErrorCode::InternalError(e.to_string()),
-            message: "Failed to update user".to_string(),
+            message: "Failed to fetch user".to_string(),
         })?;
-        match row {
-            Some(row) => Ok(row),
-            None => Err(AppError {
-                code: AppErrorCode::NotFound,
-                message: format!("User with id {} not found", id),
-            }),
-        }
+    match row {
+        Some(row) => Ok(row),
+        None => Err(AppError {
+            code: AppErrorCode::NotFound,
+            message: format!("User with id {} not found", id),
+        }),
     }
+}
 
-    async fn delete(&self, id: &str) -> Result<(), AppError> {
-        sqlx::query!(r#"DELETE FROM users WHERE id = $1"#, id)
-            .execute(&self.db)
-            .await
-            .map_err(|e| AppError {
-                code: AppErrorCode::InternalError(e.to_string()),
-                message: "Failed to delete user".to_string(),
-            })?;
-        Ok(())
+pub async fn update_user(db: &PgPool, id: &str, email: String) -> Result<User, AppError> {
+    let row = sqlx::query_as!(
+        User,
+        r#"
+            UPDATE users
+            SET email = $2
+            WHERE id = $1
+            RETURNING id, email
+        "#,
+        id,
+        email
+    )
+    .fetch_optional(db)
+    .await
+    .map_err(|e| AppError {
+        code: AppErrorCode::InternalError(e.to_string()),
+        message: "Failed to update user".to_string(),
+    })?;
+    match row {
+        Some(row) => Ok(row),
+        None => Err(AppError {
+            code: AppErrorCode::NotFound,
+            message: format!("User with id {} not found", id),
+        }),
     }
+}
+
+pub async fn delete_user(db: &PgPool, id: &str) -> Result<(), AppError> {
+    sqlx::query!(r#"DELETE FROM users WHERE id = $1"#, id)
+        .execute(db)
+        .await
+        .map_err(|e| AppError {
+            code: AppErrorCode::InternalError(e.to_string()),
+            message: "Failed to delete user".to_string(),
+        })?;
+    Ok(())
 }

--- a/src/service/registry.rs
+++ b/src/service/registry.rs
@@ -2,21 +2,15 @@ use std::sync::Arc;
 
 use crate::repository::Repository;
 
-use super::{item::ItemService, user::UserService};
 use crate::config::Config;
 
 pub struct Service {
     pub config: Arc<Config>,
-    pub item: ItemService,
-    pub user: UserService,
+    pub repo: Arc<dyn Repository>,
 }
 
 impl Service {
     pub fn new(config: Arc<Config>, repo: Arc<dyn Repository>) -> Self {
-        Self {
-            config: config.clone(),
-            item: ItemService::new(config.clone(), repo.clone()),
-            user: UserService::new(config.clone(), repo.clone()),
-        }
+        Self { config, repo }
     }
 }


### PR DESCRIPTION
example using one struct for repository and service

challenges trait on repository
- when using super trait (combination of item trait + user trait), mockall library cannot be used because it does not support supertrait. in addition, if supertrait not mocked and mock on each child trait instead, then the mock object cannot be included in the service. if we want to use supertrait, we must try using another mock library.
- when using one large trait (combining all item and user functions in 1 trait) cannot be implemented separately once the implementation of 'impl Repository for PostgresRepository' must implement all functions at once.
- the current solution is to separate the functions into separate files and call those functions in 'registry.rs'
